### PR TITLE
Add grouping report

### DIFF
--- a/definitions/reports/grouping.rb
+++ b/definitions/reports/grouping.rb
@@ -1,0 +1,30 @@
+module Checks
+  module Report
+    class Grouping < ForemanMaintain::Report
+      metadata do
+        description 'Check how resources are grouped'
+      end
+
+      def run
+        collection_count = sql_count('SELECT COUNT(*) FROM katello_host_collections')
+        collection_count_with_limit = sql_count("SELECT COUNT(*) FROM katello_host_collections
+                                                 WHERE unlimited_hosts = 'f'")
+        hostgroup = sql_count('SELECT COUNT(*) FROM hostgroups')
+        sql = <<~SQL
+          SELECT COALESCE(MAX((CHAR_LENGTH(ancestry) - CHAR_LENGTH(REPLACE(ancestry, '/', '')))) + 2, 1) AS count
+          FROM hostgroups
+        SQL
+        hostgroup_nest_level = sql_count(sql)
+        table_preference_count = sql_count('SELECT COUNT(*) FROM table_preferences')
+        config_group_count = sql_count('SELECT COUNT(*) FROM config_groups')
+        self.data = { 'host_collections_count': collection_count,
+                      'host_collections_count_with_limit': collection_count_with_limit,
+                      'hostgroup_count': hostgroup,
+                      'hostgroup_nesting': hostgroup_nest_level > 1,
+                      'hostgroup_max_nesting_level': hostgroup.zero? ? 0 : hostgroup_nest_level,
+                      'use_selectable_columns': table_preference_count > 0,
+                      'config_group_count': config_group_count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example 1:
```
# foreman-maintain report generate  | grep -e host_collections_count -e host_collections_count_with_limit -e hostgroup_count -e hostgroup_nesting -e hostgroup_max_nesting_level -e use_selectable_columns -e config_group_count
host_collections_count: 0
host_collections_count_with_limit: 0
hostgroup_count: 2
hostgroup_nesting: false
hostgroup_max_nesting_level: 1
use_selectable_columns: false
config_group_count: 0
```

Example 2:
```
# foreman-maintain report generate  | grep -e host_collections_count -e host_collections_count_with_limit -e hostgroup_count -e hostgroup_nesting -e hostgroup_max_nesting_level -e use_selectable_columns -e config_group_count
host_collections_count: 2
host_collections_count_with_limit: 1
hostgroup_count: 5
hostgroup_nesting: true
hostgroup_max_nesting_level: 3
use_selectable_columns: true
config_group_count: 1
```

TODOs:
- [x] config group count, once I add puppet to my instance