### PR TITLE
Make the report generation safe-ish

### DIFF
--- a/definitions/reports/compliance.rb
+++ b/definitions/reports/compliance.rb
@@ -6,7 +6,8 @@ module Checks
       end
 
       def run
-        data = {
+        self.data = {}
+        mapping = {
           'policy':
             'foreman_openscap_policies',
           'policy_with_tailoring_file':
@@ -20,7 +21,9 @@ module Checks
                        AND reported_at < NOW() - INTERVAL '1 year'",
         }
 
-        self.data = data.to_h { |k, v| ["compliance_#{k}_count", sql_count(v)] }
+        mapping.each do |k, query|
+          data["compliance_#{k}_count"] = sql_count(query)
+        end
       end
     end
   end

--- a/definitions/reports/external_auth_source.rb
+++ b/definitions/reports/external_auth_source.rb
@@ -7,9 +7,9 @@ module Checks
 
       # Do you use external auth source?
       def run
-        result = {}
+        self.data = {}
         # nil means no user linked to external auth source ever logged in
-        result["last_login_on_through_external_auth_source_in_days"] = nil
+        data["last_login_on_through_external_auth_source_in_days"] = nil
 
         sql = <<~SQL
           SELECT users.* FROM users
@@ -19,11 +19,9 @@ module Checks
         SQL
         users = feature(:foreman_database).query(sql)
         if (user = users.first)
-          result["last_login_on_through_external_auth_source_in_days"] =
+          data["last_login_on_through_external_auth_source_in_days"] =
             (Date.today - Date.parse(user['last_login_on'])).to_i
         end
-
-        self.data = result
       end
     end
   end

--- a/definitions/reports/grouping.rb
+++ b/definitions/reports/grouping.rb
@@ -5,28 +5,27 @@ module Checks
         description 'Check how resources are grouped'
       end
 
+      # rubocop:disable Metrics/AbcSize
       def run
-        collection_count = sql_count('katello_host_collections')
-        collection_count_with_limit = sql_count("katello_host_collections
-                                                 WHERE unlimited_hosts = 'f'")
+        self.data = {}
+        data['host_collections_count'] = sql_count('katello_host_collections')
+        data['host_collections_with_limit_count'] = sql_count("katello_host_collections
+                                                               WHERE unlimited_hosts = 'f'")
         hostgroup = sql_count('hostgroups')
         hostgroup_nest_level = sql_as_count(
           "COALESCE(MAX((CHAR_LENGTH(ancestry) - CHAR_LENGTH(REPLACE(ancestry, '/', '')))) + 2, 1)",
           'hostgroups'
         )
-        table_preference_count = sql_count('table_preferences')
+        data['hostgroup_nesting'] = hostgroup_nest_level > 1
+        data['hostgroup_max_nesting_level'] = hostgroup.zero? ? 0 : hostgroup_nest_level
+
+        data['use_selectable_columns'] = sql_count('table_preferences') > 0
 
         if table_exists('config_groups')
-          config_group_count = sql_count('config_groups')
+          data['config_group_count'] = sql_count('config_groups')
         end
-        self.data = { 'host_collections_count': collection_count,
-                      'host_collections_count_with_limit': collection_count_with_limit,
-                      'hostgroup_count': hostgroup,
-                      'hostgroup_nesting': hostgroup_nest_level > 1,
-                      'hostgroup_max_nesting_level': hostgroup.zero? ? 0 : hostgroup_nest_level,
-                      'use_selectable_columns': table_preference_count > 0,
-                      'config_group_count': config_group_count || 0 }
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/definitions/reports/grouping.rb
+++ b/definitions/reports/grouping.rb
@@ -10,11 +10,10 @@ module Checks
         collection_count_with_limit = sql_count("katello_host_collections
                                                  WHERE unlimited_hosts = 'f'")
         hostgroup = sql_count('hostgroups')
-        sql = <<~SQL
-          SELECT COALESCE(MAX((CHAR_LENGTH(ancestry) - CHAR_LENGTH(REPLACE(ancestry, '/', '')))) + 2, 1) AS count
-          FROM hostgroups
-        SQL
-        hostgroup_nest_level = sql_count(sql)
+        hostgroup_nest_level = sql_as_count(
+          "COALESCE(MAX((CHAR_LENGTH(ancestry) - CHAR_LENGTH(REPLACE(ancestry, '/', '')))) + 2, 1)",
+          'hostgroups'
+        )
         table_preference_count = sql_count('table_preferences')
 
         if table_exists('config_groups')

--- a/definitions/reports/ldap_auth_source.rb
+++ b/definitions/reports/ldap_auth_source.rb
@@ -17,63 +17,62 @@ module Checks
           acc.merge(flavor_usage(flavor))
         end
 
-        count = feature(:foreman_database).query("external_usergroups")
-        result["external_user_group_mapping_count"] = count.first['count'].to_i
+        result["external_user_group_mapping_count"] = sql_count('external_usergroups')
 
         self.data = result
       end
-    end
 
-    private
+      private
 
-    def flavor_usage(flavor)
-      result = {}
-      query_base = query_base(flavor)
-      result["ldap_auth_source_#{flavor}_count"] = sql_count(query_base)
+      def flavor_usage(flavor)
+        result = {}
+        query_base = query_base(flavor)
+        result["ldap_auth_source_#{flavor}_count"] = sql_count(query_base)
 
-      users = feature(:foreman_database).query(user_query(flavor))
-      result["users_authenticated_through_ldap_auth_source_#{flavor}"] = users.count
+        users = feature(:foreman_database).query(user_query(flavor))
+        result["users_authenticated_through_ldap_auth_source_#{flavor}"] = users.count
 
-      result["last_login_on_through_ldap_auth_source_#{flavor}_in_days"] = last_login(users)
+        result["last_login_on_through_ldap_auth_source_#{flavor}_in_days"] = last_login(users)
 
-      result["ldap_auth_source_#{flavor}_with_net_groups_count"] =
-        sql_count("#{query_base} AND use_netgroups = true")
+        result["ldap_auth_source_#{flavor}_with_net_groups_count"] =
+          sql_count("#{query_base} AND use_netgroups = true")
 
-      result["ldap_auth_source_#{flavor}_with_posix_groups_count"] =
-        sql_count("#{query_base} AND use_netgroups = false")
+        result["ldap_auth_source_#{flavor}_with_posix_groups_count"] =
+          sql_count("#{query_base} AND use_netgroups = false")
 
-      count = sql_count("#{query_base} AND onthefly_register = false")
-      result["ldap_auth_source_#{flavor}_with_account_creation_disabled_count"] = count
+        count = sql_count("#{query_base} AND onthefly_register = false")
+        result["ldap_auth_source_#{flavor}_with_account_creation_disabled_count"] = count
 
-      count = sql_count("#{query_base} AND usergroup_sync = false")
-      result["ldap_auth_source_#{flavor}_with_user_group_sync_disabled_count"] = count
+        count = sql_count("#{query_base} AND usergroup_sync = false")
+        result["ldap_auth_source_#{flavor}_with_user_group_sync_disabled_count"] = count
 
-      result
-    end
-
-    def last_login(users)
-      # nil means no user for a given LDAP type was found
-      if (user = users.first)
-        (Date.today - Date.parse(user['last_login_on'])).to_i
+        result
       end
-    end
 
-    def query_base(flavor)
-      <<~SQL
-        auth_sources
-        WHERE auth_sources.type = 'AuthSourceLdap' AND auth_sources.server_type = '#{flavor}'
-      SQL
-    end
+      def last_login(users)
+        # nil means no user for a given LDAP type was found
+        if (user = users.first)
+          (Date.today - Date.parse(user['last_login_on'])).to_i
+        end
+      end
 
-    def user_query(flavor)
-      <<~SQL
-        SELECT users.* FROM users
-        INNER JOIN auth_sources ON (auth_sources.id = users.auth_source_id)
-        WHERE auth_sources.type = 'AuthSourceLdap'
-          AND auth_sources.server_type = '#{flavor}'
-          AND users.last_login_on IS NOT NULL
-        ORDER BY users.last_login_on DESC
-      SQL
+      def query_base(flavor)
+        <<~SQL
+          auth_sources
+          WHERE auth_sources.type = 'AuthSourceLdap' AND auth_sources.server_type = '#{flavor}'
+        SQL
+      end
+
+      def user_query(flavor)
+        <<~SQL
+          SELECT users.* FROM users
+          INNER JOIN auth_sources ON (auth_sources.id = users.auth_source_id)
+          WHERE auth_sources.type = 'AuthSourceLdap'
+            AND auth_sources.server_type = '#{flavor}'
+            AND users.last_login_on IS NOT NULL
+          ORDER BY users.last_login_on DESC
+        SQL
+      end
     end
   end
 end

--- a/definitions/reports/recurring_logics.rb
+++ b/definitions/reports/recurring_logics.rb
@@ -35,7 +35,7 @@ module Checks
       private
 
       def sql_count(query)
-        super(REX_TASK_GROUP_CTE + query)
+        super(query, cte: REX_TASK_GROUP_CTE)
       end
     end
   end

--- a/definitions/reports/recurring_logics.rb
+++ b/definitions/reports/recurring_logics.rb
@@ -26,10 +26,10 @@ module Checks
       SQL
 
       def run
-        count = sql_count('indefinite_rex_recurring_logics')
-        ansible_count = sql_count("indefinite_rex_recurring_logics WHERE purpose LIKE 'ansible-%'")
-        self.data = { "recurring_logics_indefinite_rex_count": count,
-                      "recurring_logics_indefinite_rex_ansible_count": ansible_count }
+        self.data = {}
+        data['recurring_logics_indefinite_rex_count'] = sql_count('indefinite_rex_recurring_logics')
+        data['recurring_logics_indefinite_rex_ansible_count'] =
+          sql_count("indefinite_rex_recurring_logics WHERE purpose LIKE 'ansible-%'")
       end
 
       private

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -8,9 +8,7 @@ module ForemanMaintain
           scenario = run_scenario(Scenarios::Report::Generate.new({}, [:reports])).first
 
           # description can be used too
-          report_data = scenario.steps.map(&:data).reduce(&:merge).transform_keys(&:to_s)
-          # require 'pry'
-          # binding.pry
+          report_data = scenario.steps.map(&:data).compact.reduce(&:merge).transform_keys(&:to_s)
           puts report_data.to_yaml
           exit runner.exit_code
         end

--- a/lib/foreman_maintain/report.rb
+++ b/lib/foreman_maintain/report.rb
@@ -7,12 +7,13 @@ module ForemanMaintain
 
     attr_accessor :data
 
-    def sql_count(sql, column: '*')
-      sql_as_count("COUNT(#{column})", sql)
+    def sql_count(sql, column: '*', cte: '')
+      sql_as_count("COUNT(#{column})", sql, cte: cte)
     end
 
-    def sql_as_count(selection, sql)
-      feature(:foreman_database).query("SELECT #{selection} AS COUNT FROM #{sql}").first['count'].to_i
+    def sql_as_count(selection, sql, cte: '')
+      query = "#{cte} SELECT #{selection} AS COUNT FROM #{sql}"
+      feature(:foreman_database).query(query).first['count'].to_i
     end
 
     def sql_setting(name)

--- a/lib/foreman_maintain/report.rb
+++ b/lib/foreman_maintain/report.rb
@@ -8,7 +8,11 @@ module ForemanMaintain
     attr_accessor :data
 
     def sql_count(sql, column: '*')
-      feature(:foreman_database).query("SELECT COUNT(#{column}) FROM #{sql}").first['count'].to_i
+      sql_as_count("COUNT(#{column})", sql)
+    end
+
+    def sql_as_count(selection, sql)
+      feature(:foreman_database).query("SELECT #{selection} AS COUNT FROM #{sql}").first['count'].to_i
     end
 
     def sql_setting(name)

--- a/lib/foreman_maintain/report.rb
+++ b/lib/foreman_maintain/report.rb
@@ -35,7 +35,7 @@ module ForemanMaintain
       super
     rescue Error::Fail => e
       set_fail(e.message)
-    rescue Error::Warn => e
+    rescue StandardError => e
       set_warn(e.message)
     end
   end


### PR DESCRIPTION
Includes https://github.com/ares/foreman_maintain/pull/8

Failures in the individual report classes don't abort the whole generation. Additionally, the data that is collected prior to the failure are stored.